### PR TITLE
Updating inputs to make scattering order a required problem parameter

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - main
 
 jobs:
   run-tests:

--- a/HEU_MET_FAST_003/HEU_MET_FAST_003.py
+++ b/HEU_MET_FAST_003/HEU_MET_FAST_003.py
@@ -104,8 +104,8 @@ if __name__ == "__main__":
             {"block_ids": [1], "xs": xs_oralloy},
             {"block_ids": [2], "xs": xs_tuballoy},
         ],
+        scattering_order=3,
         options={
-            "scattering_order": 3,
             "use_precursors": False,
             "verbose_inner_iterations": True,
             "verbose_outer_iterations": True,
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     k_solver = NonLinearKEigenSolver(
         lbs_problem=phys,
         nl_max_its=500,
-        nl_abs_tol=1.0e-8,
+        nl_abs_tol=1.0e-9,
     )
     k_solver.Initialize()
     k_solver.Execute()

--- a/OpenSn_Logo_CAD/opensn.py
+++ b/OpenSn_Logo_CAD/opensn.py
@@ -59,8 +59,8 @@ if __name__ == "__main__":
             {"block_ids": [1], "xs": xs_source},
             {"block_ids": [2], "xs": xs_block},
         ],
+        scattering_order=0,
         options={
-            "scattering_order": 0,
             "volumetric_sources": [src],
         }
     )

--- a/Six_1g_spherical_benchmarks/Problem_1.py
+++ b/Six_1g_spherical_benchmarks/Problem_1.py
@@ -101,8 +101,8 @@ if __name__ == "__main__":
         xs_map=[
             {"block_ids": [1], "xs": xs_mat},
         ],
+        scattering_order=0,
         options={
-            "scattering_order": 0,
             "boundary_conditions": [
                 {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
                 {"name": "xmax", "type": "isotropic", "group_strength": bsrc},

--- a/Six_1g_spherical_benchmarks/Problem_2.py
+++ b/Six_1g_spherical_benchmarks/Problem_2.py
@@ -66,8 +66,8 @@ if __name__ == "__main__":
         xs_map=[
             {"block_ids": [1, 2], "xs": xs_void},
         ],
+        scattering_order=0,
         options={
-            "scattering_order": 0,
             "volumetric_sources": [mg_src],
             "boundary_conditions": [
                 {"name": "xmin", "type": "vacuum"},

--- a/Six_1g_spherical_benchmarks/Problem_3.py
+++ b/Six_1g_spherical_benchmarks/Problem_3.py
@@ -63,8 +63,8 @@ if __name__ == "__main__":
         xs_map=[
             {"block_ids": [1, 2, 3], "xs": xs_void},
         ],
+        scattering_order=0,
         options={
-            "scattering_order": 0,
             "volumetric_sources": [mg_src],
             "boundary_conditions": [
                 {"name": "xmin", "type": "vacuum"},

--- a/Six_1g_spherical_benchmarks/Problem_4.py
+++ b/Six_1g_spherical_benchmarks/Problem_4.py
@@ -65,8 +65,8 @@ if __name__ == "__main__":
             {"block_ids": [1], "xs": xs_mat},
             {"block_ids": [2], "xs": xs_void},
         ],
+        scattering_order=0,
         options={
-            "scattering_order": 0,
             "boundary_conditions": [
                 {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
                 {"name": "xmax", "type": "isotropic", "group_strength": bsrc},

--- a/Six_1g_spherical_benchmarks/Problem_5.py
+++ b/Six_1g_spherical_benchmarks/Problem_5.py
@@ -65,8 +65,8 @@ if __name__ == "__main__":
             {"block_ids": [2], "xs": xs_mat},
             {"block_ids": [1, 3], "xs": xs_void},
         ],
+        scattering_order=0,
         options={
-            "scattering_order": 0,
             "boundary_conditions": [
                 {"name": "xmin", "type": "isotropic", "group_strength": bsrc},
                 {"name": "xmax", "type": "isotropic", "group_strength": bsrc},

--- a/Six_1g_spherical_benchmarks/Problem_6.py
+++ b/Six_1g_spherical_benchmarks/Problem_6.py
@@ -66,8 +66,8 @@ if __name__ == "__main__":
             {"block_ids": [1], "xs": xs_mat},
             {"block_ids": [2], "xs": xs_void},
         ],
+        scattering_order=0,
         options={
-            "scattering_order": 0,
             "volumetric_sources": [mg_src],
             "boundary_conditions": [
                 {"name": "xmin", "type": "vacuum"},

--- a/Urban_Source/urban_source.py
+++ b/Urban_Source/urban_source.py
@@ -62,8 +62,8 @@ if __name__ == "__main__":
             {"block_ids": [2], "xs": xs_source},
             {"block_ids": [3], "xs": xs_air},
         ],
+        scattering_order=0,
         options={
-            "scattering_order": 0,
             "volumetric_sources": [src],
         }
     )

--- a/test.py
+++ b/test.py
@@ -34,7 +34,7 @@ TEST_CASES = [
     ),
     (
         os.path.join("Six_1g_spherical_benchmarks", "Problem_2.py"),
-        {"end-radius:": 1.00, "avg-value:": 8.212354},
+        {"end-radius:": 1.00, "avg-value:": 0.047223},
         12,
         1.0e-6,
     ),


### PR DESCRIPTION
In addition to scattering order updates, this PR also tightens the k tolerance on the HEU_MET_FAST benchmark problem and updates test testing workflow to test on PR and push.